### PR TITLE
CM-35207: fix centos7 to version u8

### DIFF
--- a/distros/centos-7.suite
+++ b/distros/centos-7.suite
@@ -11,8 +11,8 @@ finalize = scripts/fix_rpmdb.py
 finalize = scripts/clean_yumbootstrap.py
 
 [repositories]
-centos         = http://mirror.centos.org/centos/7/os/$basearch/
-centos-updates = http://mirror.centos.org/centos/7/updates/$basearch/
+centos         = https://vault.centos.org/7.8.2003/os/$basearch/
+centos-updates = https://vault.centos.org/7.8.2003/updates/$basearch/
 
 [environment]
 #PYTHONPATH=...


### PR DESCRIPTION
Fix centos 7 to update 7u8. To avoid problems with missing slavekernelmodules.