### PR TITLE
CM-35273: add back the rpm db fix, remove plymouth

### DIFF
--- a/distros/centos-8.suite
+++ b/distros/centos-8.suite
@@ -7,6 +7,7 @@ packages = packages/${suite}.list
 
 [post_install]
 finalize = scripts/clean_yumbootstrap.py
+finalize = scripts/fix_rpmdb.py
 
 [repositories]
 centos         = http://mirror.centos.org/centos/8/BaseOS/$basearch/os/

--- a/distros/packages/centos-8.list
+++ b/distros/packages/centos-8.list
@@ -17,8 +17,6 @@ yum
 #authconfig
 #dhclient
 chkconfig
-# graphical boot helper (used by initscripts)
-plymouth
 # ~root/.*
 rootfiles
 


### PR DESCRIPTION
This adds back the fix_rpmdb.py script to fix the $releasever problem.